### PR TITLE
Disallow claiming tokens twice for the same userId

### DIFF
--- a/contracts/interfaces/IGuildPin.sol
+++ b/contracts/interfaces/IGuildPin.sol
@@ -49,6 +49,18 @@ interface IGuildPin {
     /// @return claimed Whether the address has claimed their token.
     function hasClaimed(address account, GuildAction guildAction, uint256 id) external view returns (bool claimed);
 
+    /// @notice Whether a userId has minted a specific pin.
+    /// @dev Used to prevent double mints in the same block.
+    /// @param userId The id of the user on Guild.
+    /// @param guildAction The action the pin was minted for.
+    /// @param id The id of the guild or role the token was minted for.
+    /// @return claimed Whether the userId has claimed the pin for the given action/guildId combination.
+    function hasTheUserIdClaimed(
+        uint256 userId,
+        GuildAction guildAction,
+        uint256 id
+    ) external view returns (bool claimed);
+
     /// @notice The time interval while a signature is valid.
     /// @return validity The time interval in seconds.
     // solhint-disable func-name-mixedcase
@@ -73,9 +85,10 @@ interface IGuildPin {
     ) external payable;
 
     /// @notice Burns a token from the sender.
+    /// @param userId The id of the user on Guild.
     /// @param guildAction The action to which the token belongs to.
     /// @param guildId The id of the guild where the token belongs to.
-    function burn(GuildAction guildAction, uint256 guildId) external;
+    function burn(uint256 userId, GuildAction guildAction, uint256 guildId) external;
 
     /// @notice Updates a minted token's cid.
     /// @dev Only callable by the owner of the token.

--- a/docs/contracts/GuildPin.md
+++ b/docs/contracts/GuildPin.md
@@ -76,6 +76,12 @@ uint256 initialTokensMinted
 
 The number of tokens minted in the first version of the contract.
 
+### claimerUserIds
+
+```solidity
+mapping(uint256 => mapping(enum IGuildPin.GuildAction => mapping(uint256 => bool))) claimerUserIds
+```
+
 ## Functions
 
 ### initialize
@@ -130,6 +136,7 @@ The contract needs to be approved if ERC20 tokens are used.
 
 ```solidity
 function burn(
+    uint256 userId,
     enum IGuildPin.GuildAction guildAction,
     uint256 guildId
 ) external
@@ -141,6 +148,7 @@ Burns a token from the sender.
 
 | Name | Type | Description |
 | :--- | :--- | :---------- |
+| `userId` | uint256 | The id of the user on Guild. |
 | `guildAction` | enum IGuildPin.GuildAction | The action to which the token belongs to. |
 | `guildId` | uint256 | The id of the guild where the token belongs to. |
 
@@ -227,6 +235,33 @@ Returns true if the address has already claimed their token.
 | Name | Type | Description |
 | :--- | :--- | :---------- |
 | `claimed` | bool | Whether the address has claimed their token. |
+### hasTheUserIdClaimed
+
+```solidity
+function hasTheUserIdClaimed(
+    uint256 userId,
+    enum IGuildPin.GuildAction guildAction,
+    uint256 id
+) external returns (bool claimed)
+```
+
+Whether a userId has minted a specific pin.
+
+Used to prevent double mints in the same block.
+
+#### Parameters
+
+| Name | Type | Description |
+| :--- | :--- | :---------- |
+| `userId` | uint256 | The id of the user on Guild. |
+| `guildAction` | enum IGuildPin.GuildAction | The action the pin was minted for. |
+| `id` | uint256 | The id of the guild or role the token was minted for. |
+
+#### Return Values
+
+| Name | Type | Description |
+| :--- | :--- | :---------- |
+| `claimed` | bool | Whether the userId has claimed the pin for the given action/guildId combination. |
 ### tokenURI
 
 ```solidity

--- a/docs/contracts/interfaces/IGuildPin.md
+++ b/docs/contracts/interfaces/IGuildPin.md
@@ -29,6 +29,33 @@ Returns true if the address has already claimed their token.
 | Name | Type | Description |
 | :--- | :--- | :---------- |
 | `claimed` | bool | Whether the address has claimed their token. |
+### hasTheUserIdClaimed
+
+```solidity
+function hasTheUserIdClaimed(
+    uint256 userId,
+    enum IGuildPin.GuildAction guildAction,
+    uint256 id
+) external returns (bool claimed)
+```
+
+Whether a userId has minted a specific pin.
+
+Used to prevent double mints in the same block.
+
+#### Parameters
+
+| Name | Type | Description |
+| :--- | :--- | :---------- |
+| `userId` | uint256 | The id of the user on Guild. |
+| `guildAction` | enum IGuildPin.GuildAction | The action the pin was minted for. |
+| `id` | uint256 | The id of the guild or role the token was minted for. |
+
+#### Return Values
+
+| Name | Type | Description |
+| :--- | :--- | :---------- |
+| `claimed` | bool | Whether the userId has claimed the pin for the given action/guildId combination. |
 ### SIGNATURE_VALIDITY
 
 ```solidity
@@ -83,6 +110,7 @@ The contract needs to be approved if ERC20 tokens are used.
 
 ```solidity
 function burn(
+    uint256 userId,
     enum IGuildPin.GuildAction guildAction,
     uint256 guildId
 ) external
@@ -94,6 +122,7 @@ Burns a token from the sender.
 
 | Name | Type | Description |
 | :--- | :--- | :---------- |
+| `userId` | uint256 | The id of the user on Guild. |
 | `guildAction` | enum IGuildPin.GuildAction | The action to which the token belongs to. |
 | `guildId` | uint256 | The id of the guild where the token belongs to. |
 

--- a/test/GuildPin.spec.ts
+++ b/test/GuildPin.spec.ts
@@ -261,9 +261,9 @@ describe("GuildPin", () => {
 
         const signature = await createSignature(
           signer,
-          wallet0.address,
+          randomWallet.address,
           GuildAction.JOINED_GUILD,
-          sampleUserId + 1,
+          sampleUserId,
           sampleGuildId,
           sampleGuildName,
           sampleJoinDate,
@@ -275,9 +275,9 @@ describe("GuildPin", () => {
         const tx = pin.claim(
           ethers.ZeroAddress,
           {
-            receiver: wallet0.address,
+            receiver: randomWallet.address,
             guildAction: GuildAction.JOINED_GUILD,
-            userId: sampleUserId + 1,
+            userId: sampleUserId,
             guildId: sampleGuildId,
             guildName: sampleGuildName,
             createdAt: sampleJoinDate

--- a/test/GuildPin.spec.ts
+++ b/test/GuildPin.spec.ts
@@ -254,6 +254,43 @@ describe("GuildPin", () => {
         ).to.be.revertedWithCustomError(pin, "AlreadyClaimed");
       });
 
+      it("should revert if the userId has already claimed", async () => {
+        await pin.claim(ethers.ZeroAddress, samplePinData, timestamp, cids[0], sampleSignature, {
+          value: fee
+        });
+
+        const signature = await createSignature(
+          signer,
+          wallet0.address,
+          GuildAction.JOINED_GUILD,
+          sampleUserId + 1,
+          sampleGuildId,
+          sampleGuildName,
+          sampleJoinDate,
+          timestamp,
+          cids[0],
+          chainId,
+          await pin.getAddress()
+        );
+        const tx = pin.claim(
+          ethers.ZeroAddress,
+          {
+            receiver: wallet0.address,
+            guildAction: GuildAction.JOINED_GUILD,
+            userId: sampleUserId + 1,
+            guildId: sampleGuildId,
+            guildName: sampleGuildName,
+            createdAt: sampleJoinDate
+          },
+          timestamp,
+          cids[0],
+          signature,
+          { value: fee }
+        );
+
+        await expect(tx).to.be.revertedWithCustomError(pin, "AlreadyClaimed");
+      });
+
       it("should revert if the signature is incorrect", async () => {
         await expect(
           pin.claim(ethers.ZeroAddress, samplePinData, timestamp, cids[0], ethers.ZeroHash, {
@@ -307,10 +344,31 @@ describe("GuildPin", () => {
       });
 
       it("should set the address's claim status", async () => {
+        const hasClaimed0 = await pin.hasClaimed(wallet0.address, GuildAction.JOINED_GUILD, sampleGuildId);
         await pin.claim(ethers.ZeroAddress, samplePinData, timestamp, cids[0], sampleSignature, {
           value: fee
         });
-        expect(await pin.hasClaimed(wallet0.address, GuildAction.JOINED_GUILD, sampleGuildId)).to.eq(true);
+        const hasClaimed1 = await pin.hasClaimed(wallet0.address, GuildAction.JOINED_GUILD, sampleGuildId);
+        expect(hasClaimed0).to.eq(false);
+        expect(hasClaimed1).to.eq(true);
+      });
+
+      it("should set the userId's claim status", async () => {
+        const hasTheUserIdClaimed0 = await pin.hasTheUserIdClaimed(
+          sampleUserId,
+          GuildAction.JOINED_GUILD,
+          sampleGuildId
+        );
+        await pin.claim(ethers.ZeroAddress, samplePinData, timestamp, cids[0], sampleSignature, {
+          value: fee
+        });
+        const hasTheUserIdClaimed1 = await pin.hasTheUserIdClaimed(
+          sampleUserId,
+          GuildAction.JOINED_GUILD,
+          sampleGuildId
+        );
+        expect(hasTheUserIdClaimed0).to.eq(false);
+        expect(hasTheUserIdClaimed1).to.eq(true);
       });
 
       it("should be able to mint tokens for the same reason to different addresses", async () => {
@@ -324,7 +382,7 @@ describe("GuildPin", () => {
           signer,
           randomWallet.address,
           GuildAction.JOINED_GUILD,
-          sampleUserId,
+          sampleUserId + 1,
           sampleGuildId,
           sampleGuildName,
           sampleJoinDate,
@@ -338,7 +396,7 @@ describe("GuildPin", () => {
           {
             receiver: randomWallet.address,
             guildAction: GuildAction.JOINED_GUILD,
-            userId: sampleUserId,
+            userId: sampleUserId + 1,
             guildId: sampleGuildId,
             guildName: sampleGuildName,
             createdAt: sampleJoinDate
@@ -495,21 +553,41 @@ describe("GuildPin", () => {
 
       it("should reset hasClaimed to false", async () => {
         const hasClaimed0 = await pin.hasClaimed(wallet0.address, GuildAction.JOINED_GUILD, sampleGuildId);
-        await pin.burn(GuildAction.JOINED_GUILD, sampleGuildId);
+        await pin.burn(sampleUserId, GuildAction.JOINED_GUILD, sampleGuildId);
         const hasClaimed1 = await pin.hasClaimed(wallet0.address, GuildAction.JOINED_GUILD, sampleGuildId);
         expect(hasClaimed0).to.eq(true);
         expect(hasClaimed1).to.eq(false);
       });
 
+      it("should reset hasTheUserIdClaimed to false", async () => {
+        const hasTheUserIdClaimed0 = await pin.hasTheUserIdClaimed(
+          sampleUserId,
+          GuildAction.JOINED_GUILD,
+          sampleGuildId
+        );
+        await pin.burn(sampleUserId, GuildAction.JOINED_GUILD, sampleGuildId);
+        const hasTheUserIdClaimed1 = await pin.hasTheUserIdClaimed(
+          sampleUserId,
+          GuildAction.JOINED_GUILD,
+          sampleGuildId
+        );
+        expect(hasTheUserIdClaimed0).to.eq(true);
+        expect(hasTheUserIdClaimed1).to.eq(false);
+      });
+
       it("should decrement the total supply", async () => {
         const totalSupply0 = await pin.totalSupply();
-        await pin.burn(GuildAction.JOINED_GUILD, sampleGuildId);
+        await pin.burn(sampleUserId, GuildAction.JOINED_GUILD, sampleGuildId);
         const totalSupply1 = await pin.totalSupply();
         expect(totalSupply1).to.eq(totalSupply0 - 1n);
       });
 
       it("should burn the token", async () => {
-        await expect(pin.burn(GuildAction.JOINED_GUILD, sampleGuildId)).to.changeTokenBalance(pin, wallet0, -1);
+        await expect(pin.burn(sampleUserId, GuildAction.JOINED_GUILD, sampleGuildId)).to.changeTokenBalance(
+          pin,
+          wallet0,
+          -1
+        );
       });
     });
   });


### PR DESCRIPTION
Fixes [[GUILD-880]](https://linear.app/guildxyz/issue/GUILD-880/disable-claiming-multiple-tokens-for-the-same-userid)